### PR TITLE
Fix missing macros for annotated equation

### DIFF
--- a/annotated_with_overlay.tex
+++ b/annotated_with_overlay.tex
@@ -110,6 +110,8 @@
 % Some math definitions
 \newcommand{\lap}{\mathrm{Lap}}
 \newcommand{\pr}{\mathrm{Pr}}
+% Indicator function
+\newcommand{\ind}{\mathbb{I}}
 
 \newcommand{\Tset}{\mathcal{T}}
 \newcommand{\Dset}{\mathcal{D}}
@@ -117,7 +119,7 @@
 
 \begin{document}
 \begin{equation}
- \overbrace {\sigma({\Vec{\alpha}}, \eqnmarkbox[OliveGreen]{s}{S}) = \frac{1}{m} \sum_{j=1}^m \sum_{i=1}^n \eqnmarkbox[blue]{alpha}{\alpha_i} \ind(x_i\in \eqnmarkbox[OliveGreen]{s2}{S}) E_{ij}}^{\substack{\text{\sf \footnotesize \textcolor{purple!85}{Loss modelling function;
+ \overbrace {\sigma({\vec{\alpha}}, \eqnmarkbox[OliveGreen]{s}{S}) = \frac{1}{m} \sum_{j=1}^m \sum_{i=1}^n \eqnmarkbox[blue]{alpha}{\alpha_i} \ind(x_i\in \eqnmarkbox[OliveGreen]{s2}{S}) E_{ij}}^{\substack{\text{\sf \footnotesize \textcolor{purple!85}{Loss modelling function;
 	}} \\ \text{\sf \footnotesize \textcolor{purple!85}{Approximating $L(S,\mathcal{V})$
 }} } }
 \end{equation}


### PR DESCRIPTION
## Summary
- add indicator function macro and switch to standard `\vec{}` notation in annotated equation example

## Testing
- `pdflatex annotated_with_overlay.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68930798f5ac832e9f30f3b082d019f9